### PR TITLE
Mobile keyboard fix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.9.2
 then
 
 ```
-deno run --allow-read --allow-write --watch -A --no-check server/index.mjs
+deno run --allow-read --allow-write --watch -A --no-check server/index.ts
 ```
 
 if you change the gui code you need to refresh the browser tab

--- a/gui/app.module.js
+++ b/gui/app.module.js
@@ -26,6 +26,13 @@ class App {
         console.log("interval caught dead socket");
       }
     }, 5000);
+
+  }
+  setupInput = () => {
+    const inputElement = document.getElementById("focused-input");
+    document.getElementById('main').addEventListener('touchend', function() {
+        inputElement.focus();
+    });
   }
   setup = () => {
     if (!this.connected) {
@@ -63,6 +70,7 @@ class App {
         renderMine(this.socketId, this.room);
       });
     }
+    this.setupInput();
   };
   keydownHandler = (evt) => {
     const {

--- a/gui/index.html
+++ b/gui/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="description" content="old-unix-style character at a time talk using websockets">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>typeto.me</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=VT323');

--- a/gui/index.html
+++ b/gui/index.html
@@ -396,6 +396,12 @@
     .crt {
       animation: textShadow 1.6s infinite;
     }
+
+    #focused-input {
+      position: absolute;
+      opacity: 0;
+      z-index: -1;
+    }
   </style>
 
 </head>
@@ -413,6 +419,7 @@
       <div id="mine"></div>
     </div>
   </div>
+  <input type="text" id="focused-input" autofocus>
 </body>
 
 </html>


### PR DESCRIPTION
focuses a hidden text input when #main is tapped, allowing mobile browsers to interact

probably we got some edge cases to think about. you won't be selecting text to copy/paste from mobile, for example, with this implementation